### PR TITLE
Añade el comando rozendioanalisis

### DIFF
--- a/dcubabot.py
+++ b/dcubabot.py
@@ -101,6 +101,9 @@ def felizdia(bot, job):
     bot.send_message(chat_id="@dcfceynuba", text=felizdia_text(today))
 
 
+def rozendioanalisis(bot, update):
+    update.message.reply_text("No. Rozen todavia no dio el final de análisis.", quote=False)
+
 def main():
     try:
         global update_id

--- a/dcubabotTest.py
+++ b/dcubabotTest.py
@@ -20,7 +20,7 @@ from ptbtest import UserGenerator
 
 # Local imports
 from dcubabot import (start, estasvivo, help, listar, listaroptativa,
-                      listarotro, cubawiki, log_message, felizdia_text)
+                      listarotro, cubawiki, log_message, felizdia_text, rozendioanalisis)
 from models import *
 
 
@@ -95,6 +95,10 @@ class TestDCUBABot(unittest.TestCase):
     def test_estasvivo(self):
         self.updater.dispatcher.add_handler(CommandHandler("estasvivo", estasvivo))
         self.assert_bot_response("/estasvivo", "Sí, estoy vivo.")
+
+    def test_rozendioanalisis(self):
+        self.updater.dispatcher.add_handler(CommandHandler("rozendioanalisis", rozendioanalisis))
+        self.assert_bot_response("/rozendioanalisis", "No. Rozen todavia no dio el final de análisis.")
 
     # TODO: Rename
     def list_test(self, command, listable_type):

--- a/install.py
+++ b/install.py
@@ -16,3 +16,4 @@ with db_session:
     Command(name="listarotro", description="Muestra todos los grupos relacionados a la gente de este grupo "
                                            "(algo así como off-topics)")
     Command(name="cubawiki")
+    Command(name="rozendioanalisis", description="Te dice si Rozen ya dio el final de análisis o no")


### PR DESCRIPTION
Considero de gran importancia para la comunidad del DC el estar informado dia a dia sobre si Rozen ya dio o no el final de analisis.