### PR TITLE
Corregir typo en `/checodepers`

### DIFF
--- a/install.py
+++ b/install.py
@@ -89,7 +89,7 @@ def install_check_or_install_commands():
         check_or_install_command(name="sugerirNoticia")
         check_or_install_command(
             name="checodepers",
-            desciption="Envia un mensaje con tus consultas a los codepers" 
+            description="Envia un mensaje con tus consultas a los codepers"
                        "para que elles se pongan en contacto con vos")
 
         # Administration commands


### PR DESCRIPTION
`s/desciption/description`.
Inhibía la instalación del comando.