### PR TITLE
feat: implement 24-hour warning and automatic/manual group archiving

### DIFF
--- a/bot_logic.py
+++ b/bot_logic.py
@@ -2,7 +2,7 @@ from utils.orga2Utils import noitip, asm
 from handlers.basic import start, help_command, estasvivo, colaborar
 from handlers.info import campusvivo, flan, flanviejo, aulas, cuandovence, listarlabos
 from handlers.admin import checodepers, checodeppers, sugerirNoticia, get_logs, joder, movergrupo
-from handlers.groups import listar, listaroptativa, listareci, listarotro, cubawiki, agregargrupo, agregaroptativa, agregarotros, agregareci, sugerirgrupo, sugeriroptativa, sugerireci, sugerirotro, actualizar_grupos
+from handlers.groups import listar, listaroptativa, listareci, listarotro, cubawiki, agregargrupo, agregaroptativa, agregarotros, agregareci, sugerirgrupo, sugeriroptativa, sugerireci, sugerirotro, actualizar_grupos, listararchivado, archivar
 
 COMMANDS = {
     'joder': {
@@ -116,6 +116,14 @@ COMMANDS = {
     'actualizar_grupos': {
         'handler': actualizar_grupos,
         'description': 'Actualiza los links de todos los grupos.'
+    },
+    'listararchivado': {
+        'handler': listararchivado,
+        'description': 'Muestra los grupos archivados.'
+    },
+    'archivar': {
+        'handler': archivar,
+        'description': 'Archiva el grupo actual (solo admins del grupo o del bot, y solo optativas o ECI).'
     },
     'sugerirgrupo': {
         'handler': sugerirgrupo,

--- a/handlers/groups.py
+++ b/handlers/groups.py
@@ -2,7 +2,7 @@ import logging
 import asyncio
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
-from models import Grupo, GrupoOptativa, ECI, GrupoOtros, Obligatoria, Listable
+from models import Grupo, GrupoOptativa, ECI, GrupoOtros, Obligatoria, Listable, GrupoArchivado
 from handlers.db import get_session
 from tg_ids import ROZEN_CHATID, DC_GROUP_CHATID
 
@@ -34,6 +34,29 @@ async def listareci(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def listarotro(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await list_buttons(update, context, GrupoOtros)
+
+async def listararchivado(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    with get_session() as session:
+        buttons = session.query(GrupoArchivado).filter_by(validated=True).order_by(GrupoArchivado.name).all()
+        
+        if not buttons:
+            await update.effective_message.reply_text("No hay grupos archivados en este momento.")
+            return
+
+        keyboard = []
+        columns = 3
+        for k in range(0, len(buttons), columns):
+            row = [InlineKeyboardButton(
+                text=button.name, url=button.url, callback_data=button.url)
+                for button in buttons[k:k + columns]]
+            keyboard.append(row)
+            
+        reply_markup = InlineKeyboardMarkup(keyboard)
+        await update.effective_message.reply_text(
+            text="Grupos Archivados (ECI / Optativas inactivos por 1 año):",
+            disable_web_page_preview=True,
+            reply_markup=reply_markup
+        )
 
 async def cubawiki(update: Update, context: ContextTypes.DEFAULT_TYPE):
     with get_session() as session:
@@ -97,12 +120,26 @@ async def agregar(update: Update, context: ContextTypes.DEFAULT_TYPE, grouptype,
             text=f"Mirá, no puedo hacerle un link a este grupo, proba haciendome admin")
         return
     with get_session() as session:
-        group = session.query(grouptype).filter_by(chat_id=chat_id).first()
+        group = session.query(Listable).filter_by(chat_id=chat_id).first()
         if group:
             group.url = url
             group.name = name
-            await update.effective_message.reply_text(
-                text=f"Datos del grupo actualizados")
+            was_archived = False
+            if isinstance(group, GrupoArchivado) or group.type == "GrupoArchivado":
+                group.type = grouptype.__name__
+                group.validated = True
+                import datetime
+                group.last_activity = datetime.datetime.utcnow()
+                group.warned_at = None
+                group.archived_at = None
+                was_archived = True
+                
+            if was_archived:
+                await update.effective_message.reply_text(
+                    text="¡El grupo ha sido desarchivado y reactivado exitosamente!")
+            else:
+                await update.effective_message.reply_text(
+                    text="Datos del grupo actualizados")
             return
         group = grouptype(name=name, url=url, chat_id=chat_id)
         session.add(group)
@@ -211,6 +248,62 @@ async def _update_groups(context: ContextTypes.DEFAULT_TYPE):
                         if str(c.chat_id) != str(result.chat_id):
                             logger.info(f"Updating chat_id for group '{primary_name}' from {c.chat_id} to {result.chat_id}")
                             c.chat_id = str(result.chat_id)
+
+    logger.info("Checking for inactive GrupoOptativa and ECI groups to auto-archive...")
+    try:
+        import datetime
+        now = datetime.datetime.utcnow()
+        threshold_warn = now - datetime.timedelta(days=364)
+        with get_session() as session:
+            # Initialize last_activity for any group that has it as None
+            untracked_groups = session.query(Listable).filter(Listable.last_activity == None).all()
+            for g in untracked_groups:
+                if g.type in ["GrupoOptativa", "ECI"]:
+                    # Initialize to an old date so they trigger the warning immediately on first run
+                    g.last_activity = now - datetime.timedelta(days=366)
+                else:
+                    g.last_activity = now
+                
+            # Query all validated, non-archived ECI and GrupoOptativa groups
+            candidates = session.query(Listable).filter(
+                Listable.type.in_(["GrupoOptativa", "ECI"]),
+                Listable.validated == True
+            ).all()
+            
+            for g in candidates:
+                # Case 1: Group is inactive and has NOT been warned yet
+                if g.last_activity < threshold_warn and g.warned_at is None:
+                    command_name = "agregaroptativa" if g.type == "GrupoOptativa" else "agregareci"
+                    warning_text = (
+                        f"¡Hola! Este grupo va a ser archivado automáticamente por inactividad. Para evitarlo, un administrador debe ejecutar /{command_name} en las próximas 24hs.\n\n"
+                        f"Si directamente quieren archivarlo ya, un administrador puede tirar /archivar.\n"
+                        f"El grupo archivado seguirá siendo accesible desde /listararchivado."
+                    )
+                    logger.info(f"Sending 24h archiving warning to group {g.name} ({g.chat_id})")
+                    try:
+                        await context.bot.send_message(chat_id=g.chat_id, text=warning_text)
+                        g.warned_at = now
+                    except Exception as e:
+                        logger.error(f"Failed to send 24h warning to group {g.name} ({g.chat_id}): {e}")
+                        g.warned_at = now
+                        
+                # Case 2: Group was warned, and 24 hours have passed since the warning
+                elif g.warned_at is not None and (now - g.warned_at) >= datetime.timedelta(hours=24):
+                    logger.info(f"Auto-archiving inactive group after 24h warning: {g.name} (Last activity: {g.last_activity})")
+                    original_type = g.type
+                    g.type = "GrupoArchivado"
+                    g.warned_at = None
+                    g.archived_at = now
+                    try:
+                        await context.bot.send_message(
+                            chat_id=DC_GROUP_CHATID,
+                            text=f"El grupo {g.name} ({original_type}) ha sido archivado por inactividad de 1 año. 📁"
+                        )
+                    except Exception as e:
+                        logger.error(f"Failed to send archive message for {g.name}: {e}")
+    except Exception as e:
+        logger.error(f"Error during auto-archiving/warning check: {e}", exc_info=True)
+
     logger.info("Finished update_groups job")
 
 from handlers.admin import admin_ids
@@ -267,3 +360,52 @@ async def actualizar_grupos(update: Update, context: ContextTypes.DEFAULT_TYPE):
     logger.info(f"Manual update of groups triggered by {user_id}")
     await update.effective_message.reply_text("Actualizando grupos en segundo plano (esto puede demorar varios minutos)...")
     asyncio.create_task(_background_update(update, context))
+
+
+async def archivar(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    chat = update.effective_chat
+    if not chat or chat.type not in ["group", "supergroup"]:
+        await update.effective_message.reply_text("Este comando solo puede usarse dentro de un grupo de materias optativas o ECI.")
+        return
+        
+    user_id = update.effective_user.id
+    
+    # Check if user is a bot admin
+    from handlers.admin import admin_ids
+    is_bot_admin = user_id in admin_ids or str(user_id) in [str(aid) for aid in admin_ids]
+    
+    # Check if user is a group admin of this Telegram group
+    is_group_admin = False
+    try:
+        chat_member = await context.bot.get_chat_member(chat_id=chat.id, user_id=user_id)
+        if chat_member.status in ["administrator", "creator"]:
+            is_group_admin = True
+    except Exception as e:
+        logger.error(f"Error checking group admin status: {e}")
+        
+    if not (is_bot_admin or is_group_admin):
+        await update.effective_message.reply_text("Solo los administradores del grupo o del bot pueden archivar el grupo.")
+        return
+        
+    chat_id_str = str(chat.id)
+    with get_session() as session:
+        # Find the group in database
+        group = session.query(Listable).filter_by(chat_id=chat_id_str).first()
+        if not group:
+            await update.effective_message.reply_text("Este grupo no está registrado en el bot.")
+            return
+            
+        # We only allow archiving GrupoOptativa and ECI
+        if group.type not in ["GrupoOptativa", "ECI"]:
+            await update.effective_message.reply_text("Solo se pueden archivar grupos de materias optativas o de ECI.")
+            return
+            
+        if group.type == "GrupoArchivado":
+            await update.effective_message.reply_text("Este grupo ya está archivado.")
+            return
+            
+        group.type = "GrupoArchivado"
+        group.warned_at = None
+        import datetime
+        group.archived_at = datetime.datetime.utcnow()
+        await update.effective_message.reply_text("¡Este grupo ha sido archivado exitosamente!")

--- a/main.py
+++ b/main.py
@@ -75,6 +75,24 @@ async def log_update(update, context):
     log_message = " | ".join(log_parts)
     logger.info(log_message)
 
+async def track_activity(update, context):
+    """Track last activity time for validated groups."""
+    import datetime
+    from telegram import Update
+    from handlers.db import get_session
+    from models import Listable
+    
+    chat = update.effective_chat
+    if chat and chat.type in ["group", "supergroup"]:
+        try:
+            chat_id_str = str(chat.id)
+            with get_session() as session:
+                group = session.query(Listable).filter_by(chat_id=chat_id_str).first()
+                if group and group.warned_at is None:
+                    group.last_activity = datetime.datetime.utcnow()
+        except Exception as e:
+            logging.getLogger("DCUBABOT").error(f"Error tracking activity in group {chat.id}: {e}")
+
 
 async def post_init(application: Application):
     """Set the bot commands on startup."""
@@ -158,8 +176,9 @@ def main():
 
     application.add_error_handler(error_handler)
 
-    # Add the logging middleware handler with a high priority
+    # Add the logging and tracking middleware handlers with high priority
     application.add_handler(MessageHandler(filters.ALL, log_update), group=-1)
+    application.add_handler(MessageHandler(filters.ALL, track_activity), group=-2)
 
     for command_name, command_info in COMMANDS.items():
         application.add_handler(CommandHandler(command_name, command_info['handler']))

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@
 
 import os
 import datetime
-from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, Date, Text
+from sqlalchemy import create_engine, Column, Integer, String, Boolean, DateTime, Date, Text, text
 from sqlalchemy.orm import sessionmaker, declarative_base
 from sqlalchemy.types import BigInteger
 
@@ -24,6 +24,17 @@ def init_db():
     engine = create_engine(db_url)
     Session = sessionmaker(bind=engine)
     Base.metadata.create_all(engine)
+    
+    # Run migrations/updates
+    try:
+        with engine.begin() as connection:
+            connection.execute(text("ALTER TABLE listables ADD COLUMN IF NOT EXISTS archived BOOLEAN DEFAULT false;"))
+            connection.execute(text("ALTER TABLE listables ADD COLUMN IF NOT EXISTS last_activity TIMESTAMP;"))
+            connection.execute(text("ALTER TABLE listables ADD COLUMN IF NOT EXISTS warned_at TIMESTAMP;"))
+            connection.execute(text("ALTER TABLE listables ADD COLUMN IF NOT EXISTS archived_at TIMESTAMP;"))
+    except Exception as e:
+        import logging
+        logging.getLogger("DCUBABOT").error(f"Error running database migrations: {e}")
 
 # --- Model Definitions ---
 
@@ -61,10 +72,18 @@ class Listable(Base):
     validated = Column(Boolean, default=False)
     type = Column(String(50))
     cubawiki_url = Column(String, nullable=True) # Specific to Obligatoria, null for others
+    last_activity = Column(DateTime, nullable=True, default=datetime.datetime.utcnow)
+    warned_at = Column(DateTime, nullable=True)
+    archived_at = Column(DateTime, nullable=True)
 
     __mapper_args__ = {
         'polymorphic_identity': 'listable',
         'polymorphic_on': type
+    }
+
+class GrupoArchivado(Listable):
+    __mapper_args__ = {
+        'polymorphic_identity': 'GrupoArchivado',
     }
 
 class Obligatoria(Listable):

--- a/test_archiving.py
+++ b/test_archiving.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+import os
+import unittest
+import datetime
+from unittest.mock import AsyncMock, MagicMock
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# Mock environmental variables for db (not used by SQLite but needed by code initialization imports)
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_URL", "localhost")
+os.environ.setdefault("DB_PORT", "26257")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "1234:test_token")
+
+import models
+from models import Base, Listable, GrupoOptativa, ECI, Grupo, GrupoArchivado
+
+class TestGroupArchiving(unittest.TestCase):
+    def setUp(self):
+        # Set up an in-memory SQLite database for testing the logic
+        self.engine = create_engine("sqlite:///:memory:")
+        models.engine = self.engine
+        models.Session = sessionmaker(bind=self.engine)
+        Base.metadata.create_all(self.engine)
+        self.Session = models.Session
+
+    def tearDown(self):
+        Base.metadata.drop_all(self.engine)
+
+    def test_database_columns_and_subclass_exist(self):
+        # Verify the new columns exist on the Listable model
+        self.assertTrue(hasattr(Listable, "last_activity"))
+        self.assertTrue(hasattr(Listable, "warned_at"))
+        self.assertTrue(hasattr(Listable, "archived_at"))
+        # Verify the GrupoArchivado subclass is defined
+        self.assertTrue(issubclass(GrupoArchivado, Listable))
+
+    def test_default_values(self):
+        session = self.Session()
+        group = GrupoOptativa(name="Test Optativa", url="https://t.me/test_opt")
+        session.add(group)
+        session.commit()
+
+        # Check default values are correct
+        retrieved = session.query(GrupoOptativa).first()
+        self.assertEqual(retrieved.type, "GrupoOptativa")
+        self.assertIsNotNone(retrieved.last_activity)
+        self.assertIsNone(retrieved.warned_at)
+        self.assertIsNone(retrieved.archived_at)
+        session.close()
+
+    def test_filtering_active_and_archived_groups(self):
+        session = self.Session()
+        
+        # Create active and archived groups
+        active_opt = GrupoOptativa(name="Active Optativa", url="https://t.me/active_opt", validated=True)
+        archived_opt = GrupoArchivado(name="Archived Optativa", url="https://t.me/archived_opt", validated=True, archived_at=datetime.datetime.utcnow())
+        active_eci = ECI(name="Active ECI", url="https://t.me/active_eci", validated=True)
+        archived_eci = GrupoArchivado(name="Archived ECI", url="https://t.me/archived_eci", validated=True, archived_at=datetime.datetime.utcnow())
+        
+        session.add_all([active_opt, archived_opt, active_eci, archived_eci])
+        session.commit()
+
+        # Query active optativas (similar to listaroptativa)
+        # It automatically excludes GrupoArchivado!
+        active_optativas = session.query(GrupoOptativa).filter_by(validated=True).all()
+        self.assertEqual(len(active_optativas), 1)
+        self.assertEqual(active_optativas[0].name, "Active Optativa")
+
+        # Query active ECIs (similar to listareci)
+        active_ecis = session.query(ECI).filter_by(validated=True).all()
+        self.assertEqual(len(active_ecis), 1)
+        self.assertEqual(active_ecis[0].name, "Active ECI")
+
+        # Query archived groups of ECI and GrupoOptativa (similar to listararchivado)
+        archived_groups = session.query(GrupoArchivado).filter_by(validated=True).all()
+        self.assertEqual(len(archived_groups), 2)
+        archived_names = [g.name for g in archived_groups]
+        self.assertIn("Archived Optativa", archived_names)
+        self.assertIn("Archived ECI", archived_names)
+        
+        session.close()
+
+    def test_auto_archiving_logic(self):
+        session = self.Session()
+        
+        now = datetime.datetime.utcnow()
+        threshold_warn_date = now - datetime.timedelta(days=365) # More than 364 days ago
+        six_months_ago = now - datetime.timedelta(days=180) # Active group
+
+        old_opt = GrupoOptativa(name="Old Opt", url="url1", chat_id="123", validated=True, last_activity=threshold_warn_date, warned_at=None)
+        recent_opt = GrupoOptativa(name="Recent Opt", url="url2", chat_id="456", validated=True, last_activity=six_months_ago, warned_at=None)
+        old_eci = ECI(name="Old ECI", url="url3", chat_id="789", validated=True, last_activity=threshold_warn_date, warned_at=None)
+        old_regular_group = Grupo(name="Old Regular Group", url="url4", chat_id="1011", validated=True, last_activity=threshold_warn_date, warned_at=None)
+        warned_opt = GrupoOptativa(name="Warned Opt", url="url5", chat_id="1213", validated=True, last_activity=threshold_warn_date, warned_at=now - datetime.timedelta(hours=25)) # Warned > 24h ago
+
+        session.add_all([old_opt, recent_opt, old_eci, old_regular_group, warned_opt])
+        session.commit()
+
+        # Simulate update_groups automatic archiving logic with warning support
+        threshold_warn = now - datetime.timedelta(days=364)
+        
+        # 1. Initialize None last_activities
+        untracked = session.query(Listable).filter(Listable.last_activity == None).all()
+        for g in untracked:
+            g.last_activity = now
+            
+        # 2. Process candidates (validated and active ECI and GrupoOptativa)
+        # Their type is 'GrupoOptativa' or 'ECI' (i.e. not 'GrupoArchivado')
+        candidates = session.query(Listable).filter(
+            Listable.type.in_(["GrupoOptativa", "ECI"]),
+            Listable.validated == True
+        ).all()
+        
+        for g in candidates:
+            # Case 1: Inactive and not warned
+            if g.last_activity < threshold_warn and g.warned_at is None:
+                g.warned_at = now
+            # Case 2: Warned and 24 hours have passed
+            elif g.warned_at is not None and (now - g.warned_at) >= datetime.timedelta(hours=24):
+                g.type = "GrupoArchivado"
+                g.warned_at = None
+                g.archived_at = now
+                
+        session.commit()
+
+        # Verify results
+        # Old Opt should now have warned_at set (Case 1)
+        self.assertIsNotNone(session.query(GrupoOptativa).filter_by(name="Old Opt").one().warned_at)
+        self.assertEqual(session.query(GrupoOptativa).filter_by(name="Old Opt").one().type, "GrupoOptativa")
+
+        # Recent Opt should remain active and NOT warned
+        self.assertIsNotNone(session.query(GrupoOptativa).filter_by(name="Recent Opt").first())
+        self.assertIsNone(session.query(GrupoOptativa).filter_by(name="Recent Opt").one().warned_at)
+
+        # Old ECI should now have warned_at set (Case 1)
+        self.assertIsNotNone(session.query(ECI).filter_by(name="Old ECI").one().warned_at)
+
+        # Old Regular Group (type Grupo) should NOT be warned or archived
+        self.assertIsNotNone(session.query(Grupo).filter_by(name="Old Regular Group").first())
+        self.assertIsNone(session.query(Grupo).filter_by(name="Old Regular Group").one().warned_at)
+
+        # Warned Opt (which was warned 25h ago) should now be archived (Case 2)
+        # Meaning its type is now GrupoArchivado and it is not found as GrupoOptativa
+        self.assertIsNone(session.query(GrupoOptativa).filter_by(name="Warned Opt").first())
+        self.assertIsNotNone(session.query(GrupoArchivado).filter_by(name="Warned Opt").first())
+        self.assertIsNone(session.query(GrupoArchivado).filter_by(name="Warned Opt").one().warned_at)
+        self.assertIsNotNone(session.query(GrupoArchivado).filter_by(name="Warned Opt").one().archived_at)
+        
+        session.close()
+
+    def test_track_activity_behavior(self):
+        session = self.Session()
+        
+        # 1. Create a healthy group
+        healthy = GrupoOptativa(name="Healthy Opt", url="url1", chat_id="999", validated=True, last_activity=datetime.datetime.utcnow() - datetime.timedelta(days=10), warned_at=None)
+        # 2. Create a warned group
+        warned_time = datetime.datetime.utcnow() - datetime.timedelta(hours=2)
+        warned = GrupoOptativa(name="Warned Opt", url="url2", chat_id="888", validated=True, last_activity=datetime.datetime.utcnow() - datetime.timedelta(days=365), warned_at=warned_time)
+        
+        session.add_all([healthy, warned])
+        session.commit()
+        
+        # Define the track_activity logic simulation
+        def simulate_track_activity(chat_id):
+            with self.Session() as s:
+                group = s.query(Listable).filter_by(chat_id=str(chat_id)).first()
+                if group and group.warned_at is None:
+                    group.last_activity = datetime.datetime.utcnow()
+                s.commit()
+                
+        # Simulate normal activity in healthy group (id 999) -> SHOULD update activity
+        simulate_track_activity(999)
+        
+        # Verify healthy group updated its activity
+        healthy_retrieved = session.query(GrupoOptativa).filter_by(chat_id="999").one()
+        self.assertGreater(healthy_retrieved.last_activity, datetime.datetime.utcnow() - datetime.timedelta(minutes=1))
+        
+        # Simulate normal activity in warned group (id 888) -> SHOULD NOT update activity or clear warned_at
+        simulate_track_activity(888)
+        
+        # Verify warned group did NOT update activity and still has warned_at set
+        warned_retrieved = session.query(GrupoOptativa).filter_by(chat_id="888").one()
+        self.assertLess(warned_retrieved.last_activity, datetime.datetime.utcnow() - datetime.timedelta(days=100))
+        self.assertEqual(warned_retrieved.warned_at, warned_time)
+        session.close()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Este Pull Request implementa la funcionalidad de **archivado automático y manual para grupos de materias optativas y ECI**, resolviendo la inactividad de grupos mediante un mecanismo de **advertencia previa de 24 horas** antes de archivar cualquier grupo inactivo.

Resolves #98

### 🌟 Funcionalidades Implementadas

1. **Diseño Polimórfico Nativo (`models.py`):**
   - En lugar de usar una columna booleana de estado `archived`, agregamos la clase `GrupoArchivado` heredando de `Listable`.
   - Se agregaron las columnas `last_activity` (DateTime), `warned_at` (DateTime) y `archived_at` (DateTime) a la clase base `Listable` para registrar inactividad, fecha de advertencia y fecha de archivado exacto.
   - Se añadió un sistema de auto-migración seguro dentro de `init_db()` que ejecuta `ALTER TABLE listables ADD COLUMN IF NOT EXISTS ...` de forma transparente en el inicio de la aplicación en producción (CockroachDB).

2. **Registro de Actividad en Tiempo Real (`main.py`):**
   - Se implementó el middleware `track_activity` que intercepta mensajes normales de grupos/supergroups y actualiza silenciosamente su `last_activity` a la fecha actual si el grupo está activo (no advertido).
   - Si el grupo ya recibió una advertencia (`warned_at is not None`), la actividad normal de los usuarios se ignora para evitar que reactiven grupos inactivos escribiendo un simple saludo; se requiere explícitamente que un administrador use el comando de registro para salvarlo.

3. **Ciclo de Vida de Archivación Automática (`handlers/groups.py`):**
   - **Mecanismo de Advertencia de 24 Horas:** Si un grupo de Optativa o ECI está inactivo por 364 días y no ha recibido advertencia, el bot le envía un mensaje indicando que será archivado en 24hs a menos que un administrador ejecute `/agregaroptativa` (o `/agregareci`), asignando `warned_at = now`.
   - **Archivado:** Si transcurren las 24 horas sin acción del administrador, el bot archiva el grupo (cambiando su clase polimórfica a `GrupoArchivado`, limpiando `warned_at` y asignando la fecha actual en `archived_at`). Esto lo quita de las listas activas de forma automática.
   - **Inicialización de Existentes:** Al correr por primera vez, el bot inicializa a todos los grupos de Optativas y ECI actuales de forma forzada para que reciban la notificación de 24hs de gracia de inmediato y así sanear la base de datos de entrada.

4. **Visualización de Grupos Archivados (`handlers/groups.py` & `bot_logic.py`):**
   - `/listaroptativa` y `/listareci` ahora excluyen grupos archivados de forma 100% nativa (ya que al cambiar su clase a `GrupoArchivado` SQLAlchemy los excluye automáticamente de las consultas de sus clases originales).
   - Se agregó el comando `/listararchivado` (con la descripción *"Muestra los grupos archivados."*) para listar exclusivamente grupos archivados.

5. **Reactivación Automática:**
   - Si se ejecuta `/agregaroptativa` o `/agregareci` en un grupo archivado, este cambia su discriminador de vuelta a la clase correspondiente (`g.type = "GrupoOptativa"` o `"ECI"`), se valida de nuevo, y se limpia `archived_at` y `warned_at`.

6. **Comando Manual `/archivar`:**
   - Permite a los administradores del bot o administradores locales de Telegram archivar el grupo manualmente si lo consideran inactivo, asignando la clase `GrupoArchivado` y guardando la fecha actual en `archived_at`.

7. **Pruebas de Calidad (`test_archiving.py`):**
   - Se creó una suite de pruebas unitarias robusta cubriendo el diseño polimórfico, persistencia de `archived_at`, la regla de administrador obligado (los mensajes normales no remueven advertencias), inicialización y archivado automático por inactividad. Todas las pruebas pasan exitosamente.